### PR TITLE
Allow only trusted sources

### DIFF
--- a/draft-ietf-httpapi-privacy.md
+++ b/draft-ietf-httpapi-privacy.md
@@ -123,7 +123,9 @@ that the error can be noticed and corrected.
 Servers MAY induce such an early failure by not accepting unencrypted
 connections, e.g. on port 80. This makes it impossible for a client to send a
 credential over an insecure channel to the authentic server, as no such channel
-can be opened.
+can be opened. Servers MAY alternatively restrict connections on port 80 to
+network sources which are more trusted, such as a VPN or virtual network
+interface.
 
 However, this mitigation is limited against active network attackers, who can
 impersonate the server and accept the client's insecure connection attempt.
@@ -155,11 +157,11 @@ When the credential is next used over a secure channel, a server MAY return an
 error that indicates why the credential was revoked.
 
 Credentials in a request can take on different forms. API keys and tokens are simple
-modes for authentication, but can be abused by attackers to forfeit requests and hence
+modes for authentication, but can be abused by attackers to forge requests and hence
 should be revoked if compromised. Requests can also be authenticated using derived values,
 where they only include digital signatures or message authentication codes (MACs)
 derived from credentials but not the credentials themselves. Since an attacker cannot
-abuse the derived values to forfeit requests, the server MAY choose to not revoke the
+abuse the derived values to forge requests, the server MAY choose to not revoke the
 credentials in this case.
 
 # Client Recommendations


### PR DESCRIPTION
No issue filed for this, but implements the suggestion from @LPardue at IETF 121.